### PR TITLE
support for self signed tls

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -44,6 +44,14 @@ php artisan config:cache > /dev/null 2>&1
 echo "..."
 chown -R www-data:www-data -R $HOMEPATH
 echo "..."
+if [ -z ${FIREFLY_III_TRUSTED_CERT_URL+x} ]; then
+  export FIREFLY_III_VERIFY_TLS_CERT=true
+else
+  openssl s_client -showcerts -connect "$FIREFLY_III_TRUSTED_CERT_URL" </dev/null 2>/dev/null|openssl x509 -outform PEM > "/trusted.pem"
+  echo "..."
+  export FIREFLY_III_VERIFY_TLS_CERT="/trusted.pem"
+fi
+echo "..."
 php artisan spectre:version
 
 if [ "$WEB_SERVER" == "false" ]; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -44,12 +44,12 @@ php artisan config:cache > /dev/null 2>&1
 echo "..."
 chown -R www-data:www-data -R $HOMEPATH
 echo "..."
-if [ -z ${FIREFLY_III_TRUSTED_CERT_URL+x} ]; then
-  export FIREFLY_III_VERIFY_TLS_CERT=true
-else
-  openssl s_client -showcerts -connect "$FIREFLY_III_TRUSTED_CERT_URL" </dev/null 2>/dev/null|openssl x509 -outform PEM > "/trusted.pem"
+if [ -z ${FIREFLY_III_TRUSTED_HOST+x} ]; then
   echo "..."
-  export FIREFLY_III_VERIFY_TLS_CERT="/trusted.pem"
+else
+  openssl s_client -showcerts -connect "$FIREFLY_III_TRUSTED_HOST" </dev/null 2>/dev/null|openssl x509 -outform PEM > "/trusted.pem"
+  echo "..."
+  export FIREFLY_III_TRUSTED_CERT="/trusted.pem"
 fi
 echo "..."
 php artisan spectre:version


### PR DESCRIPTION
This PR is related to firefly-iii/spectre-importer#2 and adds support for using a self signed certificate with firefly-iii.

This is done by adding an optional variable (`FIREFLY_III_TRUSTED_HOST `) that can be set to the firefly-iii host or any url serving with the certificate intended to use (ex. 'finances.local:8443').
Since the certificate needs to exist as a `.pem` file, the certifiacte chain is retrieved using openssl and then the `FIREFLY_III_TRUSTED_CERT` variable used in the exporter will be set to the path of the retrieved certificate. 